### PR TITLE
fix: external url list

### DIFF
--- a/src/reftest-engine.js
+++ b/src/reftest-engine.js
@@ -74,6 +74,11 @@ export default class ReftestEngine {
         var path = require("path");
         var data = fs.readFileSync(reftestListFilePath, "utf-8");
         var list = parse(data);
+
+        if (this.options.useExternalServer){
+            return list;
+        }
+
         var baseDir = path.dirname(reftestListFilePath);
         // resolve path from `rootDir`
         return list.map((item)=> {


### PR DESCRIPTION
`--list`でファイルから読み込んだ際の外部のサーバのURLに対応していなかったので、こちらも対応しました。
