### PR TITLE
Breaking Change: require Node.js v4 >=

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
-node_js:
-- '0.12'
+node_js: "stable"
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ reftest-runner concept is the same, but use it with any browser that supported W
 
     npm install reftest-runner
 
+Require Node.js v4 >=
+
 ## Feature
 
 - Compare the visual output of HTMLs.


### PR DESCRIPTION
Because selenium-webdriver break semver and use Arrow Function.
- https://github.com/SeleniumHQ/selenium/issues/1170
- https://github.com/SeleniumHQ/selenium/issues/1171
